### PR TITLE
FIX: correct "options" declaration to fix crashing.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3,7 +3,10 @@
 #include"ConfigReader.h"
 int main(int argc, char** argv)
 {
-	auto options = parse_args(argc, argv);
+	// Disable stream syncronization. Only needed if mixing C/C++ I/O streams.
+	std::ios_base::sync_with_stdio(false);
+
+	auto * options = parse_args(argc, argv);
 	read_config_file(options);
 
 	//check there are no exluding flags

--- a/main.cpp
+++ b/main.cpp
@@ -3,9 +3,6 @@
 #include"ConfigReader.h"
 int main(int argc, char** argv)
 {
-	// Disable stream syncronization. Only needed if mixing C/C++ I/O streams.
-	std::ios_base::sync_with_stdio(false);
-
 	auto * options = parse_args(argc, argv);
 	read_config_file(options);
 


### PR DESCRIPTION
Couldn't even get the base command "l" to work without this fix. It's corrected with this commit.