### PR TITLE
Fix "options" declaration and HOME dir

### DIFF
--- a/ConfigReader.h
+++ b/ConfigReader.h
@@ -1,8 +1,12 @@
 #ifndef CONFIG_READER_H
 #define CONFIG_READER_H
-#include<fstream>
+#include <fstream>
 #include <stdlib.h>
-#include"OptionParser.h"
+#include "OptionParser.h"
+#include <pwd.h>
+#include <unistd.h>
+#include <sys/types.h>
+
 
 static inline std::string get_default_config()
 {
@@ -12,16 +16,25 @@ static inline std::string get_default_config()
 			"file_color=34\n"
 			"file_bg_color=40\n";
 }
+
 static void read_config_file(Options* options)
 {
+
+	// Get home directory and cast to a string.
+	const char *path;
+
+	if((path = getenv("HOME")) == NULL) {
+		path = getpwuid(getuid()) -> pw_dir;
+	}
+
+	std::string home_dir = std::string(path);
+
 	//if there is config file, than create it
 	//otherwise read and save options
-
-	auto home_dir = std::string(getenv("USERPROFILE"));
 	auto config = std::ifstream(home_dir + "/.config/.lconfig");
 	if (!config)
 	{
-		std::cout << ".lconfig file will be created at " + home_dir+"/.config" << std::endl;
+		std::cout << ".lconfig file will be created at " + home_dir +"/.config" << std::endl;
 		auto write_config = std::ofstream(home_dir + "/.config/.lconfig");
 		write_config << get_default_config();
 	}

--- a/Printer.h
+++ b/Printer.h
@@ -6,6 +6,7 @@
 #include<list>
 #include<functional>
 #include<sstream>
+#include<cmath>
 
 //namespace contains functions used by Printer's namespace ones
 //they aren't dedicated to be used out of Printer namespace

--- a/main.cpp
+++ b/main.cpp
@@ -3,7 +3,7 @@
 #include"ConfigReader.h"
 int main(int argc, char** argv)
 {
-	auto options = parse_args(argc, argv);
+	auto * options = parse_args(argc, argv);
 	read_config_file(options);
 
 	//check there are no exluding flags

--- a/main.cpp
+++ b/main.cpp
@@ -3,7 +3,9 @@
 #include"ConfigReader.h"
 int main(int argc, char** argv)
 {
+	std::ios_base::sync_with_stdio(false);
 	auto * options = parse_args(argc, argv);
+	
 	read_config_file(options);
 
 	//check there are no exluding flags


### PR DESCRIPTION
The "options" declaration in main was causing immediate crashing. This commit makes a single character change to fix that! cmath Also needed to be included in printer.h or clang complained when compiling. sync_with_stdio was also disable in main.cpp, it isn't needed and it does net a performance improvement.